### PR TITLE
Added Boltdir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 .project
 .envrc
 /inventory.yaml
+/Boltdir/


### PR DESCRIPTION
I added a Boltdir for testing with the ServiceNow API that should not
get checked into the repo.